### PR TITLE
feat: add top-level query connection decorator

### DIFF
--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -2,3 +2,4 @@ export * from './args';
 export * from './connection.type';
 export * from './page-info.type';
 export * from './resolve-connection-field.decorator';
+export * from './query-connection-field.decorator';

--- a/src/connection/query-connection-field.decorator.ts
+++ b/src/connection/query-connection-field.decorator.ts
@@ -1,0 +1,22 @@
+import { Query, QueryOptions, ReturnTypeFunc } from '@nestjs/graphql';
+import { MetadataStorage } from '../common';
+import { ConnectionTypeFactory } from './connection-type.factory';
+
+export function QueryConnection(
+  nodeTypeFunc: ReturnTypeFunc,
+  options?: Omit<QueryOptions, 'nullable'>,
+): MethodDecorator {
+  return (target: Record<string, any>, key: string | symbol, descriptor: PropertyDescriptor) => {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    const nodeType = nodeTypeFunc() as Function;
+    const typeMetadata = MetadataStorage.getClassMetadata({ target: nodeType });
+
+    const connection = ConnectionTypeFactory.create({
+      nodeTypeFunc,
+      nodeTypeName: typeMetadata.name,
+    });
+
+    const resolveFieldOptions = { ...options, nullable: true };
+    Query(() => connection, resolveFieldOptions)(target, key, descriptor);
+  };
+}

--- a/test/connection.e2e-spec.ts
+++ b/test/connection.e2e-spec.ts
@@ -196,7 +196,6 @@ describe('Connection', () => {
 
     const response = await request(app.getHttpServer()).post('/graphql').send({ query });
 
-    console.log(JSON.stringify(response.body, null, 2));
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({

--- a/test/connection.e2e-spec.ts
+++ b/test/connection.e2e-spec.ts
@@ -172,6 +172,44 @@ describe('Connection', () => {
     });
   });
 
+  it('should fetch the empire & alliance for the top-level factions connection', async () => {
+    expect.assertions(2);
+
+    const query = `
+    query FactionsConnectionQuery {
+      factions(first: 2) {
+        edges {
+          node {
+            name
+          }
+        }
+      }
+    }
+  `;
+
+    const response = await request(app.getHttpServer()).post('/graphql').send({ query });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      data: {
+        factions: {
+          edges: [
+            {
+              node: {
+                name: 'Alliance to Restore the Republic',
+              },
+            },
+            {
+              node: {
+                name: 'Galactic Empire',
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+
   it('should identify the end of the rebels ships connection', async () => {
     const query = `
       query EndOfRebelShipsQuery {

--- a/test/connection.e2e-spec.ts
+++ b/test/connection.e2e-spec.ts
@@ -181,6 +181,13 @@ describe('Connection', () => {
         edges {
           node {
             name
+            ships(first: 3) {
+              edges {
+                node {
+                  name
+                }
+              }
+            }
           }
         }
       }
@@ -188,6 +195,8 @@ describe('Connection', () => {
   `;
 
     const response = await request(app.getHttpServer()).post('/graphql').send({ query });
+
+    console.log(JSON.stringify(response.body, null, 2));
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
@@ -197,11 +206,49 @@ describe('Connection', () => {
             {
               node: {
                 name: 'Alliance to Restore the Republic',
+                ships: {
+                  edges: [
+                    {
+                      node: {
+                        name: 'X-Wing',
+                      },
+                    },
+                    {
+                      node: {
+                        name: 'Y-Wing',
+                      },
+                    },
+                    {
+                      node: {
+                        name: 'A-Wing',
+                      },
+                    },
+                  ],
+                },
               },
             },
             {
               node: {
                 name: 'Galactic Empire',
+                ships: {
+                  edges: [
+                    {
+                      node: {
+                        name: 'TIE Fighter',
+                      },
+                    },
+                    {
+                      node: {
+                        name: 'TIE Interceptor',
+                      },
+                    },
+                    {
+                      node: {
+                        name: 'Executor',
+                      },
+                    },
+                  ],
+                },
               },
             },
           ],

--- a/test/starwars-app/faction.resolver.ts
+++ b/test/starwars-app/faction.resolver.ts
@@ -30,10 +30,7 @@ export class FactionResolver extends GlobalIdFieldResolver(Faction) {
 
   @QueryConnection(() => Faction)
   factions(@Args() args: ConnectionArgs) {
-    return connectionFromArray(
-      [this.factionService.getRebels(), this.factionService.getEmpire()],
-      args,
-    );
+    return connectionFromArray(this.factionService.getFactions(), args);
   }
 
   @ResolveConnectionField(() => Ship)

--- a/test/starwars-app/faction.resolver.ts
+++ b/test/starwars-app/faction.resolver.ts
@@ -4,6 +4,7 @@ import {
   ConnectionArgs,
   ResolveConnectionField,
   Connection,
+  QueryConnection,
 } from '../../src/nestjs-relay';
 import { Faction } from './faction.type';
 import { FactionService } from './faction.service';
@@ -25,6 +26,14 @@ export class FactionResolver extends GlobalIdFieldResolver(Faction) {
   @Query(() => Faction, { nullable: true })
   empire() {
     return this.factionService.getEmpire();
+  }
+
+  @QueryConnection(() => Faction)
+  factions(@Args() args: ConnectionArgs) {
+    return connectionFromArray(
+      [this.factionService.getRebels(), this.factionService.getEmpire()],
+      args,
+    );
   }
 
   @ResolveConnectionField(() => Ship)

--- a/test/starwars-app/faction.service.ts
+++ b/test/starwars-app/faction.service.ts
@@ -53,6 +53,10 @@ export class FactionService {
     };
   }
 
+  public getFactions() {
+    return this.factions;
+  }
+
   public getShips(factionId: string) {
     const faction = this.getFaction(factionId);
     return faction ? faction.ships.map((shipId) => this.shipService.getShip(shipId)) : [];

--- a/test/starwars-app/schema.gql
+++ b/test/starwars-app/schema.gql
@@ -38,6 +38,16 @@ type Ship implements Node {
   name: String
 }
 
+type FactionEdge {
+  node: Faction
+  cursor: String!
+}
+
+type FactionConnection {
+  edges: [FactionEdge]
+  pageInfo: PageInfo!
+}
+
 type ShipEdge {
   node: Ship
   cursor: String!
@@ -68,6 +78,19 @@ type Query {
   ): [Node]!
   rebels: Faction
   empire: Faction
+  factions(
+    """Paginate before opaque cursor"""
+    before: String
+
+    """Paginate after opaque cursor"""
+    after: String
+
+    """Paginate first"""
+    first: Int
+
+    """Paginate last"""
+    last: Int
+  ): FactionConnection
 }
 
 type Mutation {


### PR DESCRIPTION
Hey @rogerballard!

Had a use-case for this, and thought it'd be easier to open a PR to discuss instead of just opening an issue. Would love to hear your thoughts. Did I miss anything, either test or code-wise?

Top-level connections might seem counterintuitive, but in essence they're a connection between the viewer and the entities you're querying.

Thanks!