### PR TITLE
fix(connections): return existing connection if already defined

### DIFF
--- a/src/connection/connection-type.factory.ts
+++ b/src/connection/connection-type.factory.ts
@@ -9,8 +9,12 @@ export interface CreateConnectionTypeArgs {
 }
 
 export class ConnectionTypeFactory {
+  private static connections = new Map();
   static create<T>(args: CreateConnectionTypeArgs): AnyConstructor<Relay.Connection<T>> {
     const nodeType = args.nodeTypeFunc() as AnyConstructor;
+    if (this.connections.has(args.nodeTypeName)) {
+      return this.connections.get(args.nodeTypeName);
+    }
 
     @ObjectType(`${args.nodeTypeName}Edge`)
     class Edge implements Relay.Edge<T> {

--- a/src/connection/connection-type.factory.ts
+++ b/src/connection/connection-type.factory.ts
@@ -38,6 +38,8 @@ export class ConnectionTypeFactory {
       pageInfo!: Relay.PageInfo;
     }
 
+    this.connections.set(args.nodeTypeName, Connection);
+
     return Connection;
   }
 }


### PR DESCRIPTION
Ran into this issue:

```
(node:28445) UnhandledPromiseRejectionWarning: Error: Schema must contain uniquely named types but contains multiple types named "ReportEdge".
```