### PR TITLE
feat: add async mutation support

### DIFF
--- a/src/mutation/relay-mutation.decorator.ts
+++ b/src/mutation/relay-mutation.decorator.ts
@@ -3,6 +3,7 @@ import { MetadataStorage } from '../common/metadata-storage.class';
 import { InputArgFactory } from './input-arg';
 import { PayloadTypeFactory } from './payload-type';
 import { getClientMutationId } from './utils';
+import { ensurePromise } from './utils/ensure-promise';
 
 export type RelayMutationOptions = Omit<MutationOptions, 'nullable'>;
 
@@ -17,9 +18,9 @@ export function RelayMutation<T>(
      * Resolver Interceptor
      */
     const originalMethod = descriptor.value;
-    descriptor.value = function (...args: any[]) {
+    descriptor.value = async function (...args: any[]) {
       const clientMutationId = getClientMutationId(args);
-      const methodResult = originalMethod.apply(this, args);
+      const methodResult = await ensurePromise(originalMethod.apply(this, args));
       return { ...methodResult, clientMutationId };
     };
 

--- a/src/mutation/utils/ensure-promise.spec.ts
+++ b/src/mutation/utils/ensure-promise.spec.ts
@@ -1,0 +1,23 @@
+import { ensurePromise, isPromise } from './ensure-promise';
+
+describe('isPromise', () => {
+  it('should return true for a Promise', () => {
+    expect(isPromise(Promise.resolve())).toBe(true);
+  });
+
+  it('should return false for everything else', () => {
+    expect(isPromise('not a Promise')).toBe(false);
+    expect(isPromise({ then: 'not a function' })).toBe(false);
+  });
+});
+
+describe('ensurePromise', () => {
+  it('should return the passed Promise', () => {
+    const promise = Promise.resolve();
+    expect(ensurePromise(promise)).toBe(promise);
+  });
+
+  it('should return everything else wrapped in a promise', () => {
+    expect(isPromise(ensurePromise('not a Promise'))).toBe(true);
+  });
+});

--- a/src/mutation/utils/ensure-promise.ts
+++ b/src/mutation/utils/ensure-promise.ts
@@ -1,0 +1,6 @@
+/** Returns true if `maybePromise` is a Promise. */
+export const isPromise = <T>(maybePromise: T | Promise<T>): maybePromise is Promise<T> =>
+  Boolean(typeof (maybePromise as any)?.then === 'function');
+
+export const ensurePromise = <T>(maybePromise: T | Promise<T>) =>
+  isPromise(maybePromise) ? maybePromise : Promise.resolve(maybePromise);


### PR DESCRIPTION
This PR enables support for `RelayMutations` to be `async` (meaning they can return a `Promise`).
Currently, such mutations lead to `null` returns.

E.g., mutations such as these resolve properly with the proposed changes:
```ts
  @RelayMutation(() => DeleteUserPayload)
  async deleteUser(@InputArg(() => DeleteUserInput) input: DeleteUserInput) {
    await this.usersService.remove(input.id.toString());
    return new DeleteUserPayload(input.id);
  }
```