### PR TITLE
Allows use of ResolvedGlobalId with class-transformer library

### DIFF
--- a/src/global-object-identification/global-id/resolved-global-id.class.ts
+++ b/src/global-object-identification/global-id/resolved-global-id.class.ts
@@ -5,8 +5,8 @@ export class ResolvedGlobalId implements RelayResolvedGlobalId {
   id!: string;
 
   constructor(args?: RelayResolvedGlobalId) {
-    this.type = args?.type;
-    this.id = args?.id;
+    this.type = args?.type || '';
+    this.id = args?.id || '';
   }
 
   toString() {

--- a/src/global-object-identification/global-id/resolved-global-id.class.ts
+++ b/src/global-object-identification/global-id/resolved-global-id.class.ts
@@ -4,9 +4,9 @@ export class ResolvedGlobalId implements RelayResolvedGlobalId {
   type!: string;
   id!: string;
 
-  constructor(args: RelayResolvedGlobalId) {
-    this.type = args.type;
-    this.id = args.id;
+  constructor(args?: RelayResolvedGlobalId) {
+    this.type = args?.type;
+    this.id = args?.id;
   }
 
   toString() {


### PR DESCRIPTION
The ResolvedGlobalId class currently requires constructor parameters. This causes an error when used with the `class-transformer` library, as this library attempts to initialise classes without contructor arguments, setting properties individually afterwards. This causes an issue when trying to use a `ResolvedGlobalId` as an argument, e.g.

```async resolveNode( resolvedGlobalId: ResolvedGlobalId){...```

Making this parameter optional allows it to work correctly with the class-transformer library while maintaining the current custom scalar logic.